### PR TITLE
Improve docs and add minimal tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Node dependencies
+node_modules/
+
+# Build output
+dist/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Environment variables
+.env
+
+# Misc
+.DS_Store
+.cache/

--- a/README.md
+++ b/README.md
@@ -1,25 +1,57 @@
+# Bmpflip
 
-A high-performance browser-based file conversion platform.
+A browser‑based file converter built around [FFmpeg.wasm](https://github.com/ffmpegwasm/ffmpeg.wasm).  The server merely serves the React client; all media processing happens on the client side for privacy and speed.
 
+## Features
 
-- Fast client-side file conversion
-- Web Worker-based parallel processing
-- Drag-and-drop interface
-- Automatic download handling
-- Responsive design
-- FFmpeg.wasm-powered conversion
+- Drag‑and‑drop UI with progress feedback
+- Web Worker powered conversions and optional ZIP packaging
+- Support for many image and video formats via a modular converter system
+- Deployed with Vite & Express, ready for Cloudflare Pages
 
+## Local Development
 
 ```bash
 npm install
-
-npm run dev
-
-npm run build
+npm run dev      # start the express server with Vite in middleware mode
 ```
 
+To create a production build run:
 
-This project is configured for deployment on Cloudflare Pages.
+```bash
+npm run build    # output goes to dist/public
+```
 
-Build command: `npm run build`
-Build output directory: `dist/public`
+## Tests
+
+Simple unit tests can be executed with:
+
+```bash
+npm test
+```
+
+## Notable Implementation
+
+The heart of the app is the `BaseFFmpegConverter` which wraps FFmpeg.wasm and reports conversion progress with detailed metadata.  It loads FFmpeg lazily and calculates compression ratios after each run.
+
+```ts
+// simplified excerpt
+async convert(file: File, output: FileFormat) {
+  await this.ensureLoaded();
+  const start = performance.now();
+  // write file, run ffmpeg, read output...
+  const conversionTime = performance.now() - start;
+  return { success: true, metadata: { conversionTime } };
+}
+```
+
+See `client/src/converters/base-ffmpeg-converter.ts` for the full logic.
+
+## Next Steps
+
+- Flesh out additional converters (e.g. documents)
+- Add end‑to‑end tests
+
+---
+
+This project was previously titled **BmptoWebp**; renaming it to **Bmpflip** better reflects the overall conversion focus.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,14 @@
+# Architecture Overview
+
+```mermaid
+flowchart TD
+    Client["React + Vite Client"] -->|HTTP| ExpressServer
+    subgraph ExpressServer
+        Server["Express + Vite DevServer"]
+    end
+    ExpressServer -->|Static files| Browser
+```
+
+This project ships a small Express server that serves the compiled React app. All
+file conversions run in the browser using FFmpeg.wasm so the server only delivers
+static assets.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "test": "vitest"
   },
   "dependencies": {
     "@ffmpeg/core": "^0.12.10",
@@ -102,7 +103,8 @@
     "tailwindcss": "^3.4.17",
     "tsx": "^4.19.1",
     "typescript": "5.6.3",
-    "vite": "^5.4.18"
+    "vite": "^5.4.18",
+    "vitest": "^1.4.0"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,0 +1,12 @@
+import { formatFileSize } from '../client/src/lib/utils';
+import { describe, it, expect } from 'vitest';
+
+describe('formatFileSize', () => {
+  it('handles kilobytes', () => {
+    expect(formatFileSize(2048)).toBe('2 KB');
+  });
+
+  it('handles zero', () => {
+    expect(formatFileSize(0)).toBe('0 Bytes');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Summary
- expand project README with context and instructions
- ignore common build artifacts
- add basic architecture notes
- set up Vitest and write a small unit test

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885544135ec8325aec07ef724111186